### PR TITLE
优化任务海报的加载逻辑，启用长缓存并保留更换海报的精确热更新

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5531,6 +5531,18 @@
                     let changeReason = '';
                     try { changeReason = JSON.parse(ev && ev.data || '{}').reason || ''; } catch (e) {}
 
+                    // 如果是海报更新通知（poster_updated:<tmdb_id>），为该节目设置缓存穿透，避免使用旧缓存
+                    try {
+                      if (typeof changeReason === 'string' && changeReason.startsWith('poster_updated:')) {
+                        const idStr = changeReason.split(':')[1] || '';
+                        const eid = parseInt(idStr, 10);
+                        if (!isNaN(eid)) {
+                          const nowTick = Date.now();
+                          this.$set(this.imageCacheBustById, eid, nowTick);
+                        }
+                      }
+                    } catch (e) {}
+
                     // 先拉取最新转存信息并重建映射（用于管理视图与进度判定）
                     try {
                       const latestRes = await axios.get('/task_latest_info');


### PR DESCRIPTION
将 `/cache/images` 改为 `Cache-Control: public, max-age=31536000, immutable` 提升切页性能；在自定义海报、刷新剧目、批量重下海报时发送 `poster_updated:<tmdb_id>`，前端 SSE 监听后对目标节目设置 `imageCacheBustById`，仅变更项追加 `?t=` 强制刷新，未变更项命中缓存。